### PR TITLE
Remove italic and blue color from section titles

### DIFF
--- a/src/components/ui/SectionHeader.module.css
+++ b/src/components/ui/SectionHeader.module.css
@@ -34,12 +34,11 @@
 }
 
 .highlight {
-  font-style: italic;
-  color: var(--cyan-muted);
+  color: var(--cream);
 }
 
 .dot {
-  color: var(--orange);
+  color: var(--cream);
 }
 
 .description {

--- a/src/components/ui/SectionHeader.tsx
+++ b/src/components/ui/SectionHeader.tsx
@@ -25,7 +25,7 @@ export function SectionHeader({
           {titleHighlight && (
             <>
               <br />
-              <em className={styles.highlight}>{titleHighlight}</em>
+              <span className={styles.highlight}>{titleHighlight}</span>
             </>
           )}
           <span className={styles.dot}>.</span>


### PR DESCRIPTION
Removes the italic and blue styling from section title highlights.

- Changed `<em>` to `<span>` in SectionHeader to remove browser default italic
- Removed `font-style: italic` and `color: var(--cyan-muted)` from `.highlight` class
- Changed `.dot` color from orange to cream for uniform full stop color

Closes #4

Generated with [Claude Code](https://claude.ai/code)